### PR TITLE
Enable continuous FIFO mode

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,3 +3,7 @@ Arduino_LSM9DS1 ?.?.? - ????.??.??
 Arduino_LSM9DS1 1.0.0 - 2019.07.31
 
 * Initial release
+
+Arduino_LSM9DS1 1.1.0 - 2020.02.11
+
+* Added support for FIFO continuous reading of values

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Arduino_LSM9DS1
-version=1.0.1
+version=1.1.0
 author=Arduino
 maintainer=Arduino <info@arduino.cc>
 sentence=Allows you to read the accelerometer, magnetometer and gyroscope values from the LSM9DS1 IMU on your Arduino Nano 33 BLE Sense.

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Arduino_LSM9DS1
-version=1.0.0
+version=1.0.1
 author=Arduino
 maintainer=Arduino <info@arduino.cc>
 sentence=Allows you to read the accelerometer, magnetometer and gyroscope values from the LSM9DS1 IMU on your Arduino Nano 33 BLE Sense.

--- a/src/LSM9DS1.cpp
+++ b/src/LSM9DS1.cpp
@@ -76,12 +76,21 @@ int LSM9DS1Class::begin()
   writeRegister(LSM9DS1_ADDRESS_M, LSM9DS1_CTRL_REG2_M, 0x00); // 4 Gauss
   writeRegister(LSM9DS1_ADDRESS_M, LSM9DS1_CTRL_REG3_M, 0x00); // Continuous conversion mode
 
+  return 1;
+}
+
+void LSM9DS1Class::setContinuousMode() {
   // Enable FIFO (see docs https://www.st.com/resource/en/datasheet/DM00103319.pdf)
   writeRegister(LSM9DS1_ADDRESS, 0x23, 0x02);
   // Set continuous mode
   writeRegister(LSM9DS1_ADDRESS, 0x2E, 0xC0);
+}
 
-  return 1;
+void LSM9DS1Class::setOneShotMode() {
+  // Disable FIFO (see docs https://www.st.com/resource/en/datasheet/DM00103319.pdf)
+  writeRegister(LSM9DS1_ADDRESS, 0x23, 0x00);
+  // Disable continuous mode
+  writeRegister(LSM9DS1_ADDRESS, 0x2E, 0x00);
 }
 
 void LSM9DS1Class::end()

--- a/src/LSM9DS1.cpp
+++ b/src/LSM9DS1.cpp
@@ -76,6 +76,11 @@ int LSM9DS1Class::begin()
   writeRegister(LSM9DS1_ADDRESS_M, LSM9DS1_CTRL_REG2_M, 0x00); // 4 Gauss
   writeRegister(LSM9DS1_ADDRESS_M, LSM9DS1_CTRL_REG3_M, 0x00); // Continuous conversion mode
 
+  // Enable FIFO (see docs https://www.st.com/resource/en/datasheet/DM00103319.pdf)
+  writeRegister(LSM9DS1_ADDRESS, 0x23, 0x02);
+  // Set continuous mode
+  writeRegister(LSM9DS1_ADDRESS, 0x2E, 0xC0);
+
   return 1;
 }
 
@@ -109,7 +114,8 @@ int LSM9DS1Class::readAcceleration(float& x, float& y, float& z)
 
 int LSM9DS1Class::accelerationAvailable()
 {
-  if (readRegister(LSM9DS1_ADDRESS, LSM9DS1_STATUS_REG) & 0x01) {
+  // Read FIFO_SRC. If any of the rightmost 8 bits have a value, there is data.
+  if (readRegister(LSM9DS1_ADDRESS, 0x2F) & 63) {
     return 1;
   }
 

--- a/src/LSM9DS1.h
+++ b/src/LSM9DS1.h
@@ -28,6 +28,11 @@ class LSM9DS1Class {
     int begin();
     void end();
 
+    // Controls whether a FIFO is continuously filled, or a single reading is stored.
+    // Defaults to one-shot.
+    void setContinuousMode();
+    void setOneShotMode();
+
     // Accelerometer
     virtual int readAcceleration(float& x, float& y, float& z); // Results are in G (earth gravity).
     virtual int accelerationAvailable(); // Number of samples in the FIFO.


### PR DESCRIPTION
We need this change to run the magic wand TensorFlow example. At the moment we ask users to manually patch the library themselves after downloading, which isn't ideal.