### PR TITLE
Correct units shown for sample rate in example sketch

### DIFF
--- a/examples/SimpleMagnetometer/SimpleMagnetometer.ino
+++ b/examples/SimpleMagnetometer/SimpleMagnetometer.ino
@@ -27,7 +27,7 @@ void setup() {
   }
   Serial.print("Magnetic field sample rate = ");
   Serial.print(IMU.magneticFieldSampleRate());
-  Serial.println(" uT");
+  Serial.println(" Hz");
   Serial.println();
   Serial.println("Magnetic Field in uT");
   Serial.println("X\tY\tZ");


### PR DESCRIPTION
The output incorrectly specified the units as uT, rather than Hz.

Fixes https://github.com/arduino-libraries/Arduino_LSM9DS1/issues/9 (Thanks @navrit!)